### PR TITLE
Fix line splitting and collection creation

### DIFF
--- a/CsvToCollection/csvToCollection.js
+++ b/CsvToCollection/csvToCollection.js
@@ -1,4 +1,3 @@
-
 (function (root, factory) {
   if (typeof exports === 'object' && typeof require === 'function') {
     module.exports = factory(require("Backbone"), require('underscore'));
@@ -12,7 +11,7 @@
     factory(Backbone, _);
   }
 }(this, function(Backbone, _) {
-  Backbone.csvToCollection = function ToCollection (pCsvFile) {  
+  Backbone.csvToCollection = function ToCollection (pCsvFile) {
     if(pCsvFile.target.files === 'undefined')
     {
       throw new Error("There is no file.");
@@ -22,27 +21,24 @@
       throw new Error("The file must be in csv format");
     }
     var reader = new FileReader();
-    reader.onload = (function(_this) {
-      return function(e) {    
-        var collection, content, header, i, model, y;
-        collection = new Backbone.Collection();       
-        header = e.target.result.split('\n')[0].split(";");
-        content = e.target.result.split('\n');
-        content.splice(0, 1);
-        content.forEach(function(a){
-          var i, model;
-          i=0;
-          model = new Backbone.Model();
-          header.forEach(function(b) {            
-            model.set(header[i],a.split(';')[i]);
-            return i++;
-          });
-          collection.add(model);
-        });       
-        var event = new CustomEvent("Load", { "detail" : collection });
-        document.dispatchEvent(event);    
-      };
-    })(pCsvFile);
+    reader.onload = function(e) {
+      var collection, content, header, model, resultSplit, event;
+      collection = new Backbone.Collection();
+      resultSplit = e.target.result.replace(/\r/g, "\n").split('\n');
+      header = _.head(resultSplit).split(",");
+      content = _.tail(resultSplit).map(function(line){
+        return line.split(",");
+      });
+      event = new CustomEvent("Load", { "detail" : _.reduce(content, function(acc, col){
+        acc.add(_.chain(header).zip(col).reduce(
+          function(acc, val){
+            acc.set(_.head(val), _.last(val));
+            return acc;
+          }, new Backbone.Model({})).value());
+        return acc;
+      }, collection)});
+      document.dispatchEvent(event);
+    };
     reader.readAsText(pCsvFile.target.files.item(0));
   };
   return Backbone.csvToCollection;


### PR DESCRIPTION
Lines may now be split by `\r\n`.
Columns are now split by `,` instead of `;`.
Collection and Model construction implemented as a `fold`.
Removes unnecessary `_this` and corresponding wrapper function.
